### PR TITLE
Allow to change the return type when downloading pdf

### DIFF
--- a/lib/tripletex_ruby_client/api/invoice_api.rb
+++ b/lib/tripletex_ruby_client/api/invoice_api.rb
@@ -177,6 +177,7 @@ module TripletexRubyClient
     # @param invoice_id Invoice ID from which PDF is downloaded.
     # @param [Hash] opts the optional parameters
     # @option opts [BOOLEAN] :download Equals (default to true)
+    # @option opts [String] :return_type 'String' type set as default
     # @return [String]
     def download_pdf(invoice_id, opts = {})
       data, _status_code, _headers = download_pdf_with_http_info(invoice_id, opts)
@@ -188,6 +189,7 @@ module TripletexRubyClient
     # @param invoice_id Invoice ID from which PDF is downloaded.
     # @param [Hash] opts the optional parameters
     # @option opts [BOOLEAN] :download Equals
+    # @option opts [String] :return_type 'String' type set as default
     # @return [Array<(String, Fixnum, Hash)>] String data, response status code and response headers
     def download_pdf_with_http_info(invoice_id, opts = {})
       if @api_client.config.debugging
@@ -212,6 +214,9 @@ module TripletexRubyClient
       # form parameters
       form_params = {}
 
+      # return_type
+      return_type = opts[:'return_type'] || 'String'
+
       # http body (model)
       post_body = nil
       auth_names = ['tokenAuthScheme']
@@ -221,7 +226,7 @@ module TripletexRubyClient
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'String')
+        :return_type => return_type)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: InvoiceApi#download_pdf\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/lib/tripletex_ruby_client/version.rb
+++ b/lib/tripletex_ruby_client/version.rb
@@ -1,3 +1,3 @@
 module TripletexRubyClient
-  VERSION = '1.0.8'
+  VERSION = '1.0.9'
 end


### PR DESCRIPTION
Was set by default to string, but someone might want to download in tempfile, in order to not consume memory