### PR TITLE
Download pdf's as files

### DIFF
--- a/lib/tripletex_ruby_client/api/ledgervoucher_api.rb
+++ b/lib/tripletex_ruby_client/api/ledgervoucher_api.rb
@@ -134,6 +134,7 @@ module TripletexRubyClient
     # 
     # @param voucher_id Voucher ID from which PDF is downloaded.
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :return_type 'String' type set as default
     # @return [String]
     def download_pdf(voucher_id, opts = {})
       data, _status_code, _headers = download_pdf_with_http_info(voucher_id, opts)
@@ -144,6 +145,7 @@ module TripletexRubyClient
     # 
     # @param voucher_id Voucher ID from which PDF is downloaded.
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :return_type 'String' type set as default
     # @return [Array<(String, Fixnum, Hash)>] String data, response status code and response headers
     def download_pdf_with_http_info(voucher_id, opts = {})
       if @api_client.config.debugging
@@ -167,6 +169,9 @@ module TripletexRubyClient
       # form parameters
       form_params = {}
 
+      # return_type
+      return_type = opts[:'return_type'] || 'String'
+
       # http body (model)
       post_body = nil
       auth_names = ['tokenAuthScheme']
@@ -176,7 +181,7 @@ module TripletexRubyClient
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'String')
+        :return_type => return_type)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: LedgervoucherApi#download_pdf\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/lib/tripletex_ruby_client/api/reminder_api.rb
+++ b/lib/tripletex_ruby_client/api/reminder_api.rb
@@ -76,6 +76,7 @@ module TripletexRubyClient
     #
     # @param reminder_id Reminder ID from which PDF is downloaded.
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :return_type 'String' type set as default
     # @return [String]
     def download_pdf(reminder_id, opts = {})
       data, _status_code, _headers = download_pdf_with_http_info(reminder_id, opts)
@@ -86,6 +87,7 @@ module TripletexRubyClient
     #
     # @param reminder_id Reminder ID from which PDF is downloaded.
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :return_type 'String' type set as default
     # @return [Array<(String, Fixnum, Hash)>] String data, response status code and response headers
     def download_pdf_with_http_info(reminder_id, opts = {})
       if @api_client.config.debugging
@@ -109,6 +111,9 @@ module TripletexRubyClient
       # form parameters
       form_params = {}
 
+      # return_type
+      return_type = opts[:'return_type'] || 'String'
+
       # http body (model)
       post_body = nil
       auth_names = ['tokenAuthScheme']
@@ -118,7 +123,7 @@ module TripletexRubyClient
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'String')
+        :return_type => return_type)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: ReminderApi#download_pdf\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/lib/tripletex_ruby_client/api/salarycompilation_api.rb
+++ b/lib/tripletex_ruby_client/api/salarycompilation_api.rb
@@ -24,6 +24,7 @@ module TripletexRubyClient
     # @param employee_id Element ID
     # @param [Hash] opts the optional parameters
     # @option opts [Integer] :year Must be between 1900-2100. Defaults to previous year.
+    # @option opts [String] :return_type 'String' type set as default
     # @return [String]
     def download_pdf(employee_id, opts = {})
       data, _status_code, _headers = download_pdf_with_http_info(employee_id, opts)
@@ -35,6 +36,7 @@ module TripletexRubyClient
     # @param employee_id Element ID
     # @param [Hash] opts the optional parameters
     # @option opts [Integer] :year Must be between 1900-2100. Defaults to previous year.
+    # @option opts [String] :return_type 'String' type set as default
     # @return [Array<(String, Fixnum, Hash)>] String data, response status code and response headers
     def download_pdf_with_http_info(employee_id, opts = {})
       if @api_client.config.debugging
@@ -60,6 +62,9 @@ module TripletexRubyClient
       # form parameters
       form_params = {}
 
+      # return_type
+      return_type = opts[:'return_type'] || 'String'
+
       # http body (model)
       post_body = nil
       auth_names = ['tokenAuthScheme']
@@ -69,7 +74,7 @@ module TripletexRubyClient
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'String')
+        :return_type => return_type)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: SalarycompilationApi#download_pdf\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/lib/tripletex_ruby_client/api/salarypayslip_api.rb
+++ b/lib/tripletex_ruby_client/api/salarypayslip_api.rb
@@ -23,6 +23,7 @@ module TripletexRubyClient
     # 
     # @param id Element ID
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :return_type 'String' type set as default
     # @return [String]
     def download_pdf(id, opts = {})
       data, _status_code, _headers = download_pdf_with_http_info(id, opts)
@@ -33,6 +34,7 @@ module TripletexRubyClient
     # 
     # @param id Element ID
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :return_type 'String' type set as default
     # @return [Array<(String, Fixnum, Hash)>] String data, response status code and response headers
     def download_pdf_with_http_info(id, opts = {})
       if @api_client.config.debugging
@@ -56,6 +58,9 @@ module TripletexRubyClient
       # form parameters
       form_params = {}
 
+      # return_type
+      return_type = opts[:'return_type'] || 'String'
+
       # http body (model)
       post_body = nil
       auth_names = ['tokenAuthScheme']
@@ -65,7 +70,7 @@ module TripletexRubyClient
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'String')
+        :return_type => return_type)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: SalarypayslipApi#download_pdf\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/lib/tripletex_ruby_client/api/supplier_invoice_api.rb
+++ b/lib/tripletex_ruby_client/api/supplier_invoice_api.rb
@@ -389,6 +389,7 @@ module TripletexRubyClient
     # 
     # @param invoice_id Invoice ID from which document is downloaded.
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :return_type 'String' type set as default
     # @return [String]
     def download_pdf(invoice_id, opts = {})
       data, _status_code, _headers = download_pdf_with_http_info(invoice_id, opts)
@@ -399,6 +400,7 @@ module TripletexRubyClient
     # 
     # @param invoice_id Invoice ID from which document is downloaded.
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :return_type 'String' type set as default
     # @return [Array<(String, Fixnum, Hash)>] String data, response status code and response headers
     def download_pdf_with_http_info(invoice_id, opts = {})
       if @api_client.config.debugging
@@ -422,6 +424,9 @@ module TripletexRubyClient
       # form parameters
       form_params = {}
 
+      # return_type
+      return_type = opts[:'return_type'] || 'String'
+
       # http body (model)
       post_body = nil
       auth_names = ['tokenAuthScheme']
@@ -431,7 +436,7 @@ module TripletexRubyClient
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'String')
+        :return_type => return_type)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: SupplierInvoiceApi#download_pdf\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/lib/tripletex_ruby_client/version.rb
+++ b/lib/tripletex_ruby_client/version.rb
@@ -1,3 +1,3 @@
 module TripletexRubyClient
-  VERSION = '1.0.9'
+  VERSION = '1.0.9.1'
 end

--- a/lib/tripletex_ruby_client/version.rb
+++ b/lib/tripletex_ruby_client/version.rb
@@ -1,3 +1,3 @@
 module TripletexRubyClient
-  VERSION = '1.0.9.1'
+  VERSION = '1.0.11'
 end


### PR DESCRIPTION
Same as this: https://github.com/rubynor/tripletex_ruby_client/pull/4, but it enables downloading pdfs as tempfiles in all endpoints